### PR TITLE
Fix: Bill forgot to remove

### DIFF
--- a/libs/renderer/src/nitro/room/object/visualization/room/RoomPlane.ts
+++ b/libs/renderer/src/nitro/room/object/visualization/room/RoomPlane.ts
@@ -249,12 +249,6 @@ export class RoomPlane implements IRoomPlane {
     this._rectangleMasks = null;
     this._maskPixels = null;
 
-    if (this._maskBitmapData) {
-      this._maskBitmapData.destroy(true);
-
-      this._maskBitmapData = null;
-    }
-
     this._disposed = true;
   }
 


### PR DESCRIPTION
I saw this commit to fix a mask error https://github.com/billsonnn/nitro-renderer/commit/354f72c9c5b8e1b21105bbfd77e9afa320cf3bfd but I believe the issue is still here. I have this one room, if I enter it once; it works fine. If I re-enter the room this errors pops up

Uncaught TypeError: Cannot read properties of null (reading 'width')
    at RenderTexture2.get (Texture.ts:648:26)
    at _PlaneTextureCache.clearAndFillRenderTexture (RoomTextureUtils.ts:96:38)
    at _PlaneTextureCache.createAndFillRenderTexture (RoomTextureUtils.ts:76:21)
    at _RoomPlane.updateMask (RoomPlane.ts:791:55)
    at _RoomPlane.getTexture (RoomPlane.ts:327:22)
    at _RoomPlane.update (RoomPlane.ts:571:34)
    at _RoomVisualization.updatePlanes (RoomVisualization.ts:744:30)
    at _RoomVisualization.update (RoomVisualization.ts:190:17)
    at RoomSpriteCanvas.renderObject (RoomSpriteCanvas.ts:455:41)
    at RoomSpriteCanvas.render (RoomSpriteCanvas.ts:372:51)