### PR TITLE
FIX: compile error outdated lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@pixi/tilemap": "^3.2.2",
     "@pixi/utils": "~6.5.0",
     "@swc/helpers": "~0.5.3",
-    "@tanstack/react-virtual": "^3.0.0-alpha.0",
+    "@tanstack/react-virtual": "3.0.0-alpha.0",
     "gifuct-js": "^2.1.2",
     "howler": "^2.2.3",
     "pako": "^2.0.4",


### PR DESCRIPTION
A later version of `@tanstack/react-virtual` causes nx to fail the build process.

```
nitro/apps/frontend/src/common/InfiniteScroll.tsx:1:8
1: import {useVirtual} from "@tanstack/react-virtual";
           ^
2: import {FC, Fragment, ReactElement, useEffect, useRef, useState} from "react";

 >  NX   "useVirtual" is not exported by "node_modules/@tanstack/react-virtual/dist/esm/index.js", imported by "apps/frontend/src/common/InfiniteScroll.tsx".
 ```
 
 This small patch allows the build to compile.